### PR TITLE
Implement invoice dashboard listing and downloads

### DIFF
--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Invoice;
+use App\Models\InvoicePerson;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Response;
+use Illuminate\Support\Facades\Storage;
+use Inertia\Inertia;
+use Inertia\Response as InertiaResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class InvoiceController extends Controller
+{
+    public function index(Request $request): InertiaResponse
+    {
+        /** @var User|null $user */
+        $user = $request->user();
+        $perPage = (int) $request->integer('per_page', 10);
+
+        $paginator = Invoice::query()
+            ->with([
+                'people.person.groups',
+                'people.lines' => fn ($query) => $query
+                    ->select('id', 'invoice_person_id', 'price_without_vat', 'price_with_vat'),
+            ])
+            ->latest('created_at')
+            ->paginate($perPage > 0 ? $perPage : 10)
+            ->withQueryString()
+            ->through(fn (Invoice $invoice) => $this->transformInvoiceForUser($invoice, $user));
+
+        return Inertia::render('Dashboard', [
+            'invoices' => $paginator,
+            'filters' => [
+                'per_page' => $perPage,
+                'role' => data_get($user, 'role'),
+            ],
+        ]);
+    }
+
+    public function download(Request $request, Invoice $invoice, string $format): StreamedResponse
+    {
+        $format = strtolower($format);
+
+        abort_unless(in_array($format, ['csv', 'pdf'], true), 404);
+
+        $invoice->loadMissing(['people.person.groups', 'people.lines']);
+
+        /** @var User|null $user */
+        $user = $request->user();
+        $filteredPeople = $this->filterPeopleForRole($invoice->people, data_get($user, 'role'));
+        $invoice->setRelation('people', $filteredPeople);
+
+        $path = sprintf('invoices/%d.%s', $invoice->id, $format);
+        $filename = $this->buildDownloadFileName($invoice, $format);
+
+        if (Storage::disk('local')->exists($path)) {
+            return Storage::disk('local')->download($path, $filename);
+        }
+
+        return Response::streamDownload(function () use ($invoice, $format) {
+            if ($format === 'csv') {
+                $this->streamCsv($invoice);
+
+                return;
+            }
+
+            echo $this->generateSimplePdf($invoice);
+        }, $filename, [
+            'Content-Type' => $format === 'csv' ? 'text/csv' : 'application/pdf',
+        ]);
+    }
+
+    private function transformInvoiceForUser(Invoice $invoice, ?User $user): array
+    {
+        $people = $this->filterPeopleForRole($invoice->people, data_get($user, 'role'));
+
+        $lineCount = $people->reduce(
+            fn (int $carry, InvoicePerson $invoicePerson) => $carry + $invoicePerson->lines->count(),
+            0
+        );
+
+        return [
+            'id' => $invoice->id,
+            'source_filename' => $invoice->source_filename,
+            'row_count' => $invoice->row_count,
+            'created_at' => optional($invoice->created_at)->toDateTimeString(),
+            'people_count' => $people->count(),
+            'line_count' => $lineCount,
+            'totals' => [
+                'without_vat' => round($people->sum('total_without_vat'), 2),
+                'with_vat' => round($people->sum('total_with_vat'), 2),
+                'limit' => round($people->sum('limit'), 2),
+                'payable' => round($people->sum('payable'), 2),
+            ],
+            'downloads' => [
+                'csv' => route('invoices.download', ['invoice' => $invoice->id, 'format' => 'csv']),
+                'pdf' => route('invoices.download', ['invoice' => $invoice->id, 'format' => 'pdf']),
+            ],
+        ];
+    }
+
+    private function filterPeopleForRole(Collection $people, $role): Collection
+    {
+        if (empty($role) || $role === 'admin') {
+            return $people;
+        }
+
+        return $people->filter(function (InvoicePerson $invoicePerson) use ($role) {
+            $person = $invoicePerson->person;
+
+            if ($person === null) {
+                return false;
+            }
+
+            return $person->groups->contains(fn ($group) => $group->value === $role);
+        })->values();
+    }
+
+    private function buildDownloadFileName(Invoice $invoice, string $format): string
+    {
+        $base = $invoice->source_filename ?: 'invoice-' . $invoice->id;
+        $name = pathinfo($base, PATHINFO_FILENAME) ?: $base;
+
+        return sprintf('%s.%s', str($name)->slug('-'), $format);
+    }
+
+    private function streamCsv(Invoice $invoice): void
+    {
+        $handle = fopen('php://output', 'w');
+
+        if ($handle === false) {
+            return;
+        }
+
+        fputcsv($handle, [
+            'Employee',
+            'Phone',
+            'Service',
+            'Price without VAT',
+            'Price with VAT',
+        ]);
+
+        foreach ($invoice->people as $person) {
+            foreach ($person->lines as $line) {
+                fputcsv($handle, [
+                    optional($person->person)->name,
+                    $person->phone,
+                    $line->service_name,
+                    number_format((float) $line->price_without_vat, 2, '.', ''),
+                    number_format((float) $line->price_with_vat, 2, '.', ''),
+                ]);
+            }
+        }
+
+        fclose($handle);
+    }
+
+    private function generateSimplePdf(Invoice $invoice): string
+    {
+        $lines = [];
+
+        foreach ($invoice->people as $person) {
+            foreach ($person->lines as $line) {
+                $lines[] = sprintf(
+                    '%s - %s: %s / %s',
+                    optional($person->person)->name ?? 'Unknown',
+                    $line->service_name,
+                    number_format((float) $line->price_without_vat, 2),
+                    number_format((float) $line->price_with_vat, 2)
+                );
+            }
+        }
+
+        $content = 'Invoice #' . $invoice->id . "\n" . implode("\n", $lines);
+        $escaped = str_replace(['(', ')', '\\'], ['\\(', '\\)', '\\\\'], $content);
+
+        $stream = "BT /F1 12 Tf 72 720 Td (" . $escaped . ") Tj ET";
+        $length = strlen($stream);
+
+        $objects = [
+            "1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj\n",
+            "2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj\n",
+            "3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >> endobj\n",
+            "4 0 obj << /Length {$length} >> stream\n{$stream}\nendstream endobj\n",
+            "5 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj\n",
+        ];
+
+        $pdf = "%PDF-1.4\n";
+        $offsets = [];
+
+        foreach ($objects as $object) {
+            $offsets[] = strlen($pdf);
+            $pdf .= $object;
+        }
+
+        $xref = "xref\n0 6\n0000000000 65535 f \n";
+
+        foreach ($offsets as $offset) {
+            $xref .= sprintf("%010d 00000 n \n", $offset);
+        }
+
+        $pdf .= $xref;
+        $pdf .= "trailer << /Size 6 /Root 1 0 R >>\nstartxref\n" . strlen($pdf) . "\n%%EOF";
+
+        return $pdf;
+    }
+}

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
 class Invoice extends Model
 {
@@ -27,5 +28,15 @@ class Invoice extends Model
     public function people(): HasMany
     {
         return $this->hasMany(InvoicePerson::class);
+    }
+
+    public function lines(): HasManyThrough
+    {
+        return $this->hasManyThrough(
+            InvoiceLine::class,
+            InvoicePerson::class,
+            'invoice_id',
+            'invoice_person_id'
+        );
     }
 }

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -1,28 +1,159 @@
 <script setup>
+import { computed } from 'vue';
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
-import { Head } from '@inertiajs/vue3';
+import { Head, Link } from '@inertiajs/vue3';
+
+const props = defineProps({
+    invoices: {
+        type: Object,
+        required: true,
+    },
+    filters: {
+        type: Object,
+        default: () => ({}),
+    },
+});
+
+const hasInvoices = computed(() => props.invoices?.data?.length > 0);
+
+const formatCurrency = (value) => {
+    if (value === null || value === undefined) {
+        return '—';
+    }
+
+    return Number(value).toLocaleString('cs-CZ', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    });
+};
 </script>
 
 <template>
-    <Head title="Přehled zmh" />
+    <Head title="Přehled faktur" />
 
     <AuthenticatedLayout>
         <template #header>
-            <h2
-                class="text-xl font-semibold leading-tight text-gray-800"
-            >
-                Přehled
-            </h2>
+            <div class="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+                <h2 class="text-xl font-semibold leading-tight text-gray-800">
+                    Přehled faktur
+                </h2>
+                <p class="text-sm text-gray-500">
+                    Role: {{ filters.role ?? 'nezjištěna' }}
+                </p>
+            </div>
         </template>
 
         <div class="py-12">
             <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
-                <div
-                    class="overflow-hidden bg-white shadow-sm sm:rounded-lg"
-                >
+                <div class="overflow-hidden bg-white shadow-sm sm:rounded-lg">
                     <div class="p-6 text-gray-900">
-                        Vítejte zpět {{ $page.props.auth.user.name }}.
-                        Jste úspěšně přihlášen.
+                        <div v-if="hasInvoices" class="space-y-4">
+                            <div class="overflow-x-auto">
+                                <table class="min-w-full divide-y divide-gray-200">
+                                    <thead class="bg-gray-50">
+                                        <tr>
+                                            <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                                                ID
+                                            </th>
+                                            <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                                                Soubor
+                                            </th>
+                                            <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                                                Vytvořeno
+                                            </th>
+                                            <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                                                Osoby / Položky
+                                            </th>
+                                            <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                                                Celkem bez DPH
+                                            </th>
+                                            <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                                                Celkem s DPH
+                                            </th>
+                                            <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                                                Limit / K úhradě
+                                            </th>
+                                            <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                                                Stažení
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody class="divide-y divide-gray-200 bg-white">
+                                        <tr
+                                            v-for="invoice in invoices.data"
+                                            :key="invoice.id"
+                                            class="hover:bg-gray-50"
+                                        >
+                                            <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-700">
+                                                {{ invoice.id }}
+                                            </td>
+                                            <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-700">
+                                                {{ invoice.source_filename ?? '—' }}
+                                            </td>
+                                            <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-700">
+                                                {{ invoice.created_at ?? '—' }}
+                                            </td>
+                                            <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-700 text-right">
+                                                {{ invoice.people_count }} / {{ invoice.line_count }}
+                                            </td>
+                                            <td class="whitespace-nowrap px-4 py-3 text-sm text-right text-gray-700">
+                                                {{ formatCurrency(invoice.totals.without_vat) }}
+                                            </td>
+                                            <td class="whitespace-nowrap px-4 py-3 text-sm text-right text-gray-700">
+                                                {{ formatCurrency(invoice.totals.with_vat) }}
+                                            </td>
+                                            <td class="whitespace-nowrap px-4 py-3 text-sm text-right text-gray-700">
+                                                {{ formatCurrency(invoice.totals.limit) }} /
+                                                {{ formatCurrency(invoice.totals.payable) }}
+                                            </td>
+                                            <td class="whitespace-nowrap px-4 py-3 text-sm text-right">
+                                                <div class="flex justify-end gap-2">
+                                                    <a
+                                                        :href="invoice.downloads.csv"
+                                                        class="inline-flex items-center rounded border border-gray-300 px-2 py-1 text-xs font-medium text-gray-700 transition hover:bg-gray-100"
+                                                    >
+                                                        CSV
+                                                    </a>
+                                                    <a
+                                                        :href="invoice.downloads.pdf"
+                                                        class="inline-flex items-center rounded border border-gray-300 px-2 py-1 text-xs font-medium text-gray-700 transition hover:bg-gray-100"
+                                                    >
+                                                        PDF
+                                                    </a>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+
+                            <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                                <p class="text-sm text-gray-600">
+                                    Zobrazeno {{ invoices.data.length }} z {{ invoices.total }} faktur.
+                                </p>
+                                <nav class="flex flex-wrap items-center gap-1">
+                                    <Link
+                                        v-for="link in invoices.links"
+                                        :key="`${link.label}-${link.url}`"
+                                        :href="link.url ?? '#'"
+                                        class="rounded px-3 py-1 text-sm font-medium transition"
+                                        :class="[
+                                            link.active
+                                                ? 'bg-indigo-600 text-white shadow'
+                                                : 'bg-gray-100 text-gray-700 hover:bg-gray-200',
+                                            !link.url ? 'cursor-not-allowed opacity-50' : '',
+                                        ]"
+                                        v-html="link.label"
+                                        :aria-disabled="!link.url"
+                                        @click="link.url ? null : $event.preventDefault()"
+                                    />
+                                </nav>
+                            </div>
+                        </div>
+
+                        <div v-else class="text-center text-gray-500">
+                            Zatím nejsou dostupné žádné faktury pro vaši roli.
+                        </div>
                     </div>
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\GroupController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ImportController;
 use App\Http\Controllers\PersonController;
+use App\Http\Controllers\InvoiceController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -16,9 +17,14 @@ Route::get('/', function () {
         'phpVersion' => PHP_VERSION,
     ]);
 });
-Route::get('/dashboard', function () {
-    return Inertia::render('Dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+Route::get('/dashboard', [InvoiceController::class, 'index'])
+    ->middleware(['auth', 'verified'])
+    ->name('dashboard');
+
+Route::get('/invoices/{invoice}/download/{format}', [InvoiceController::class, 'download'])
+    ->whereIn('format', ['csv', 'pdf'])
+    ->middleware(['auth', 'verified'])
+    ->name('invoices.download');
 
 Route::get('/import', [ImportController::class, 'index'])->middleware(['auth', 'verified'])->name('import');
 Route::post('/import/process', [ImportController::class, 'processImport'])->middleware(['auth', 'verified'])->name('import.process');


### PR DESCRIPTION
## Summary
- add an InvoiceController that assembles paginated invoice headers with role-aware aggregates and download streams
- expose invoice line relations and wire dashboard plus download routes through the new controller
- replace the dashboard page with an invoice data grid including CSV and PDF download controls

## Testing
- php artisan test *(fails: database file at path [/workspace/phones_billing/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0832c7a8833182aaf7302239da39