### PR TITLE
Add secured invoice detail view with email notifications

### DIFF
--- a/app/Data/ImportedPersonData.php
+++ b/app/Data/ImportedPersonData.php
@@ -48,6 +48,7 @@ class ImportedPersonData implements Arrayable
     public float $celkem_s_dph = 0;
     public float $zaplati = 0;
     public ?float $vat = null;
+    public ?int $invoicePersonId = null;
 
     /** @var ServiceEntry[] */
     public array $sluzby = [];
@@ -83,6 +84,7 @@ class ImportedPersonData implements Arrayable
             'celkem' => round($this->celkem,4),
             'celkem_s_dph' => round($this->celkem_s_dph,4),
             'zaplati' => round($this->zaplati,2),
+            'invoice_person_id' => $this->invoicePersonId,
             'sluzby' => array_map(fn($s) => $s->toArray(), $this->sluzby),
             'aplikovana_pravidla' => $this->aplikovanaPravidla,
         ];

--- a/app/Mail/InvoiceBreakdownMail.php
+++ b/app/Mail/InvoiceBreakdownMail.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\InvoicePerson;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class InvoiceBreakdownMail extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    public InvoicePerson $invoicePerson;
+
+    public function __construct(InvoicePerson $invoicePerson)
+    {
+        $this->invoicePerson = $invoicePerson->loadMissing(['invoice', 'person', 'lines']);
+    }
+
+    public function build(): self
+    {
+        $person = $this->invoicePerson->person;
+        $invoice = $this->invoicePerson->invoice;
+
+        $subject = 'Vyúčtování #' . ($invoice?->id ?? $this->invoicePerson->id);
+
+        return $this->subject($subject)
+            ->view('emails.invoices.breakdown')
+            ->with([
+                'invoicePerson' => $this->invoicePerson,
+                'person' => $person,
+                'invoice' => $invoice,
+                'lines' => $this->invoicePerson->lines,
+            ]);
+    }
+}

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Notifications\Notifiable;
 
 class Person extends Model
@@ -36,5 +37,10 @@ class Person extends Model
     public function invoiceLines()
     {
         return $this->hasMany(InvoiceLine::class);
+    }
+
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'person_user')->withTimestamps();
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -44,5 +45,10 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function people(): BelongsToMany
+    {
+        return $this->belongsToMany(Person::class, 'person_user')->withTimestamps();
     }
 }

--- a/app/Policies/InvoicePersonPolicy.php
+++ b/app/Policies/InvoicePersonPolicy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\InvoicePerson;
+use App\Models\User;
+
+class InvoicePersonPolicy
+{
+    public function view(User $user, InvoicePerson $invoicePerson): bool
+    {
+        return $this->isLinkedToUser($user, $invoicePerson);
+    }
+
+    public function email(User $user, InvoicePerson $invoicePerson): bool
+    {
+        return $this->isLinkedToUser($user, $invoicePerson);
+    }
+
+    protected function isLinkedToUser(User $user, InvoicePerson $invoicePerson): bool
+    {
+        if (($user->role ?? null) === 'admin') {
+            return true;
+        }
+
+        $person = $invoicePerson->person;
+
+        if ($person === null) {
+            return false;
+        }
+
+        return $user->people()->where('people.id', $person->id)->exists();
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Models\InvoicePerson;
+use App\Policies\InvoicePersonPolicy;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\ServiceProvider;
 
@@ -21,5 +24,6 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Vite::prefetch(concurrency: 3);
+        Gate::policy(InvoicePerson::class, InvoicePersonPolicy::class);
     }
 }

--- a/database/migrations/2025_10_01_110707_create_person_user_table.php
+++ b/database/migrations/2025_10_01_110707_create_person_user_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('person_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('person_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['person_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('person_user');
+    }
+};

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -108,6 +108,13 @@ const formatCurrency = (value) => {
                                             </td>
                                             <td class="whitespace-nowrap px-4 py-3 text-sm text-right">
                                                 <div class="flex justify-end gap-2">
+                                                    <Link
+                                                        v-if="invoice.detail_url"
+                                                        :href="invoice.detail_url"
+                                                        class="inline-flex items-center rounded border border-indigo-600 px-2 py-1 text-xs font-medium text-indigo-600 transition hover:bg-indigo-50"
+                                                    >
+                                                        Detail
+                                                    </Link>
                                                     <a
                                                         :href="invoice.downloads.csv"
                                                         class="inline-flex items-center rounded border border-gray-300 px-2 py-1 text-xs font-medium text-gray-700 transition hover:bg-gray-100"

--- a/resources/js/Pages/ImportTable.vue
+++ b/resources/js/Pages/ImportTable.vue
@@ -82,13 +82,20 @@ async function sendNotification(name, phone, data) {
     const key = `${name}-${phone}`;
     isSendingNotification.value[key] = true;
     notificationMessage.value[key] = '';
+    const invoicePersonId = data.invoice_person_id;
+
+    if (!invoicePersonId) {
+        notificationMessage.value[key] = 'Chybí vazba na vyúčtování – nelze odeslat e-mail.';
+        isSendingNotification.value[key] = false;
+        return;
+    }
+
     try {
-        // TODO: ZDE POZDĚJI NAHRADÍŠ ENDPOINTEM (např. await axios.post('/api/send-notification', { ... }))
-        // await axios.post('/api/send-notification', { name, phone, data });
-        await new Promise(resolve => setTimeout(resolve, 1300)); // Dummy simulace
-        notificationMessage.value[key] = 'E-mail byl úspěšně odeslán!(Dělám si srandu, nebyl.)';
+        const response = await axios.post(`/invoices/${invoicePersonId}/email`);
+        notificationMessage.value[key] = response?.data?.message ?? 'E-mail byl úspěšně odeslán.';
     } catch (e) {
-        notificationMessage.value[key] = 'Chyba při odesílání e-mailu!';
+        const message = e?.response?.data?.message ?? 'Chyba při odesílání e-mailu!';
+        notificationMessage.value[key] = message;
     } finally {
         isSendingNotification.value[key] = false;
     }

--- a/resources/js/Pages/Invoices/Show.vue
+++ b/resources/js/Pages/Invoices/Show.vue
@@ -1,0 +1,156 @@
+<script setup>
+import { computed } from 'vue';
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head, Link } from '@inertiajs/vue3';
+
+const props = defineProps({
+    invoicePerson: {
+        type: Object,
+        required: true,
+    },
+});
+
+const hasLines = computed(() => props.invoicePerson?.lines?.length > 0);
+
+const formatCurrency = (value) => {
+    if (value === null || value === undefined) {
+        return '—';
+    }
+
+    return Number(value).toLocaleString('cs-CZ', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    }) + ' Kč';
+};
+</script>
+
+<template>
+    <Head title="Vyúčtování" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <div class="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <h2 class="text-xl font-semibold leading-tight text-gray-800">
+                        Vyúčtování pro {{ invoicePerson.person?.name ?? 'neznámého uživatele' }}
+                    </h2>
+                    <p class="text-sm text-gray-500">
+                        Telefon: <span class="font-medium text-gray-700">{{ invoicePerson.phone }}</span>
+                    </p>
+                </div>
+                <div class="text-sm text-gray-500">
+                    <p>
+                        Faktura:
+                        <span class="font-medium text-gray-700">
+                            <template v-if="invoicePerson.invoice">
+                                #{{ invoicePerson.invoice.id }}
+                                <span v-if="invoicePerson.invoice.source_filename">
+                                    – {{ invoicePerson.invoice.source_filename }}
+                                </span>
+                            </template>
+                            <template v-else>
+                                Bez vazby
+                            </template>
+                        </span>
+                    </p>
+                    <p v-if="invoicePerson.invoice?.created_at">
+                        Vytvořeno: {{ invoicePerson.invoice.created_at }}
+                    </p>
+                </div>
+            </div>
+        </template>
+
+        <div class="py-12">
+            <div class="mx-auto max-w-5xl space-y-8 sm:px-6 lg:px-8">
+                <div class="overflow-hidden rounded-lg bg-white shadow">
+                    <div class="border-b border-gray-200 bg-gray-50 px-6 py-4">
+                        <h3 class="text-lg font-medium text-gray-900">Souhrn</h3>
+                    </div>
+                    <div class="grid gap-4 px-6 py-6 sm:grid-cols-2">
+                        <div>
+                            <p class="text-sm text-gray-500">Limit</p>
+                            <p class="text-lg font-semibold text-gray-900">{{ formatCurrency(invoicePerson.limit) }}</p>
+                        </div>
+                        <div>
+                            <p class="text-sm text-gray-500">Celkem bez DPH</p>
+                            <p class="text-lg font-semibold text-gray-900">{{ formatCurrency(invoicePerson.total_without_vat) }}</p>
+                        </div>
+                        <div>
+                            <p class="text-sm text-gray-500">Celkem s DPH</p>
+                            <p class="text-lg font-semibold text-gray-900">{{ formatCurrency(invoicePerson.total_with_vat) }}</p>
+                        </div>
+                        <div>
+                            <p class="text-sm text-gray-500">K úhradě</p>
+                            <p class="text-lg font-semibold text-gray-900">{{ formatCurrency(invoicePerson.payable) }}</p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="overflow-hidden rounded-lg bg-white shadow">
+                    <div class="border-b border-gray-200 bg-gray-50 px-6 py-4">
+                        <div class="flex items-center justify-between">
+                            <h3 class="text-lg font-medium text-gray-900">Položky</h3>
+                            <Link
+                                :href="route('invoices.email', { invoicePerson: invoicePerson.id })"
+                                method="post"
+                                as="button"
+                                type="button"
+                                class="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow transition hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                            >
+                                Odeslat e-mail
+                            </Link>
+                        </div>
+                    </div>
+                    <div v-if="hasLines" class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Služba</th>
+                                    <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Tarif</th>
+                                    <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Skupina</th>
+                                    <th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wide text-gray-500">Cena bez DPH</th>
+                                    <th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wide text-gray-500">Cena s DPH</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-gray-200 bg-white">
+                                <tr
+                                    v-for="line in invoicePerson.lines"
+                                    :key="line.id"
+                                    class="hover:bg-gray-50"
+                                >
+                                    <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-700">{{ line.service_name }}</td>
+                                    <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-700">{{ line.tariff ?? '—' }}</td>
+                                    <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-700">{{ line.group_name ?? '—' }}</td>
+                                    <td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-700">{{ formatCurrency(line.price_without_vat) }}</td>
+                                    <td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-700">{{ formatCurrency(line.price_with_vat) }}</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div v-else class="px-6 py-6 text-sm text-gray-500">
+                        Pro tuto osobu nejsou evidovány žádné položky.
+                    </div>
+                </div>
+
+                <div v-if="invoicePerson.applied_rules?.length" class="overflow-hidden rounded-lg bg-white shadow">
+                    <div class="border-b border-gray-200 bg-gray-50 px-6 py-4">
+                        <h3 class="text-lg font-medium text-gray-900">Aplikovaná pravidla</h3>
+                    </div>
+                    <ul class="divide-y divide-gray-200">
+                        <li
+                            v-for="(rule, index) in invoicePerson.applied_rules"
+                            :key="index"
+                            class="px-6 py-4 text-sm text-gray-700"
+                        >
+                            <p class="font-medium text-gray-900">{{ rule.popis ?? 'Pravidlo' }}</p>
+                            <p v-if="rule.sluzba" class="text-gray-600">Služba: {{ rule.sluzba }}</p>
+                            <p v-if="rule.cena_s_dph" class="text-gray-600">
+                                Cena s DPH: {{ formatCurrency(rule.cena_s_dph) }}
+                            </p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/views/emails/invoices/breakdown.blade.php
+++ b/resources/views/emails/invoices/breakdown.blade.php
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="cs">
+<head>
+    <meta charset="UTF-8">
+    <title>Vyúčtování</title>
+</head>
+<body style="font-family: Arial, sans-serif; color: #111827;">
+    <h1 style="font-size: 20px;">Dobrý den {{ $person->name ?? 'uživateli' }},</h1>
+    <p>
+        posíláme vám přehled vyúčtování
+        @if($invoice)
+            za fakturu <strong>#{{ $invoice->id }}</strong>
+            @if($invoice->source_filename)
+                ({{ $invoice->source_filename }})
+            @endif
+        @else
+            za evidovaný záznam
+        @endif
+        .
+    </p>
+
+    <h2 style="font-size: 18px; margin-top: 20px;">Souhrn</h2>
+    <ul>
+        <li><strong>Telefon:</strong> {{ $invoicePerson->phone }}</li>
+        <li><strong>Celkem bez DPH:</strong> {{ number_format($invoicePerson->total_without_vat, 2, ',', ' ') }} Kč</li>
+        <li><strong>Celkem s DPH:</strong> {{ number_format($invoicePerson->total_with_vat, 2, ',', ' ') }} Kč</li>
+        <li><strong>Limit:</strong> {{ number_format($invoicePerson->limit, 2, ',', ' ') }} Kč</li>
+        <li><strong>K úhradě:</strong> {{ number_format($invoicePerson->payable, 2, ',', ' ') }} Kč</li>
+    </ul>
+
+    @if($lines->isNotEmpty())
+        <h2 style="font-size: 18px; margin-top: 20px;">Detailní položky</h2>
+        <table style="width: 100%; border-collapse: collapse;">
+            <thead>
+                <tr>
+                    <th style="border-bottom: 1px solid #D1D5DB; text-align: left; padding: 8px;">Služba</th>
+                    <th style="border-bottom: 1px solid #D1D5DB; text-align: left; padding: 8px;">Tarif</th>
+                    <th style="border-bottom: 1px solid #D1D5DB; text-align: left; padding: 8px;">Skupina</th>
+                    <th style="border-bottom: 1px solid #D1D5DB; text-align: right; padding: 8px;">Cena bez DPH</th>
+                    <th style="border-bottom: 1px solid #D1D5DB; text-align: right; padding: 8px;">Cena s DPH</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($lines as $line)
+                    <tr>
+                        <td style="padding: 6px; border-bottom: 1px solid #E5E7EB;">{{ $line->service_name }}</td>
+                        <td style="padding: 6px; border-bottom: 1px solid #E5E7EB;">{{ $line->tariff ?? '—' }}</td>
+                        <td style="padding: 6px; border-bottom: 1px solid #E5E7EB;">{{ $line->group_name ?? '—' }}</td>
+                        <td style="padding: 6px; border-bottom: 1px solid #E5E7EB; text-align: right;">{{ number_format($line->price_without_vat, 2, ',', ' ') }} Kč</td>
+                        <td style="padding: 6px; border-bottom: 1px solid #E5E7EB; text-align: right;">{{ number_format($line->price_with_vat, 2, ',', ' ') }} Kč</td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    @endif
+
+    @if(!empty($invoicePerson->applied_rules))
+        <h2 style="font-size: 18px; margin-top: 20px;">Aplikovaná pravidla</h2>
+        <ul>
+            @foreach($invoicePerson->applied_rules as $rule)
+                <li>
+                    {{ $rule['popis'] ?? 'Pravidlo' }}
+                    @if(!empty($rule['sluzba']))
+                        – {{ $rule['sluzba'] }}
+                    @endif
+                    @if(!empty($rule['cena_s_dph']))
+                        ({{ number_format($rule['cena_s_dph'], 2, ',', ' ') }} Kč s DPH)
+                    @endif
+                </li>
+            @endforeach
+        </ul>
+    @endif
+
+    <p style="margin-top: 24px;">Pokud máte k vyúčtování dotazy, obraťte se prosím na podporu.</p>
+    <p>S pozdravem,<br>Telefonní účtárna</p>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,14 @@ Route::get('/invoices/{invoice}/download/{format}', [InvoiceController::class, '
     ->middleware(['auth', 'verified'])
     ->name('invoices.download');
 
+Route::get('/invoices/{invoicePerson}', [InvoiceController::class, 'show'])
+    ->middleware(['auth', 'verified'])
+    ->name('invoices.show');
+
+Route::post('/invoices/{invoicePerson}/email', [InvoiceController::class, 'email'])
+    ->middleware(['auth', 'verified'])
+    ->name('invoices.email');
+
 Route::get('/import', [ImportController::class, 'index'])->middleware(['auth', 'verified'])->name('import');
 Route::post('/import/process', [ImportController::class, 'processImport'])->middleware(['auth', 'verified'])->name('import.process');
 Route::post('/import-table', [ImportController::class, 'processImport'])->middleware(['auth', 'verified'])->name('import.process');


### PR DESCRIPTION
## Summary
- add policy-protected routes and controller actions for viewing and emailing individual invoice people
- build an Inertia invoice detail page and expose links from the dashboard for eligible users
- persist invoice person identifiers through the import flow and send queued breakdown emails via a new mailable
- relate users to people through a pivot table and register the corresponding authorization policy

## Testing
- php artisan test *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0a701bf883318d6798ba80ae933f