### PR TITLE
Add invoice import detail view and routing

### DIFF
--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -194,6 +194,12 @@ const formatCurrency = (value) => {
                                                     class="flex justify-end gap-2"
                                                 >
                                                     <Link
+                                                        :href="route('import.show', invoice.id)"
+                                                        class="inline-flex items-center rounded border border-indigo-600 px-2 py-1 text-xs font-medium text-indigo-600 transition hover:bg-indigo-50"
+                                                    >
+                                                        Import
+                                                    </Link>
+                                                    <Link
                                                         v-if="
                                                             invoice.detail_url
                                                         "

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,8 +36,10 @@ Route::post('/invoices/{invoicePerson}/email', [InvoiceController::class, 'email
 
 Route::get('/import', [ImportController::class, 'index'])->middleware(['auth', 'verified'])->name('import');
 Route::post('/import/process', [ImportController::class, 'processImport'])->middleware(['auth', 'verified'])->name('import.process');
-Route::post('/import-table', [ImportController::class, 'processImport'])->middleware(['auth', 'verified'])->name('import.process');
-Route::get('/import-table', [ImportController::class, 'index'])->middleware(['auth', 'verified'])->name('import');
+Route::get('/import/{invoice}', [ImportController::class, 'show'])
+    ->middleware(['auth', 'verified'])
+    ->whereNumber('invoice')
+    ->name('import.show');
 Route::get('/import/data', function () {
     return [
         'tariffs' => \App\Models\Tariff::all(),


### PR DESCRIPTION
## Summary
- add an ImportController@show endpoint that rebuilds import data from stored invoices
- redirect successful imports to the new route and adjust routing to expose /import/{invoice}
- update the import table and dashboard pages to support GET rendering, missing data states, and quick links

## Testing
- php artisan test *(fails: vendor/autoload.php is missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1c4296bc8331b54f97408484cef7