### PR TITLE
Improve test bootstrap and sqlite compatibility

### DIFF
--- a/database/migrations/2025_06_09_160827_alter_group_user_to_group_person.php
+++ b/database/migrations/2025_06_09_160827_alter_group_user_to_group_person.php
@@ -15,8 +15,13 @@ class AlterGroupUserToGroupPerson extends Migration
 
         // 2. Drop původní foreign keys
         Schema::table('group_person', function (Blueprint $table) {
-            try { $table->dropForeign('group_user_user_id_foreign'); } catch (\Throwable $e) {}
-            try { $table->dropForeign('group_user_group_id_foreign'); } catch (\Throwable $e) {}
+            if (Schema::hasColumn('group_person', 'user_id')) {
+                $table->dropForeign(['user_id']);
+            }
+
+            if (Schema::hasColumn('group_person', 'group_id')) {
+                $table->dropForeign(['group_id']);
+            }
         });
 
         // 3. Přejmenuj sloupec user_id na person_id

--- a/database/migrations/2025_09_08_101151_create_billing_table.php
+++ b/database/migrations/2025_09_08_101151_create_billing_table.php
@@ -34,7 +34,7 @@ return new class extends Migration
             $table->json('applied_rules')->nullable();
             $table->timestamps();
 
-            $table->unique(['invoice_id', 'person_id']);
+            $table->unique(['invoice_id', 'person_id', 'phone']);
         });
 
         Schema::create('invoice_lines', function (Blueprint $table) {

--- a/database/migrations/2025_10_15_000000_create_person_phones_table.php
+++ b/database/migrations/2025_10_15_000000_create_person_phones_table.php
@@ -38,14 +38,11 @@ return new class extends Migration
         }
 
         Schema::table('people', function (Blueprint $table) {
-            if (!Schema::hasColumn('people', 'phone')) {
+            if (! Schema::hasColumn('people', 'phone')) {
                 return;
             }
 
-            if (DB::getDriverName() !== 'sqlite') {
-                $table->dropUnique('people_phone_unique');
-            }
-
+            $table->dropUnique(['phone']);
             $table->dropColumn('phone');
         });
     }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,10 +20,11 @@
     <php>
         <env name="APP_ENV" value="testing"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
+        <env name="APP_KEY" value="base64:yL+88KDEHX4NtYyHnT1gvW2uWY9rP46ssaPEb8n1iVY="/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value="database/database.sqlite"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -11,7 +11,9 @@
         <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
         <!-- Scripts -->
         @routes
-        @vite(['resources/js/app.js', "resources/js/Pages/{$page['component']}.vue"])
+        @unless (app()->environment('testing'))
+            @vite(['resources/js/app.js', "resources/js/Pages/{$page['component']}.vue"])
+        @endunless
         @inertiaHead
     </head>
     <body class="font-sans antialiased">

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Application;
+
+trait CreatesApplication
+{
+    /**
+     * Creates the application.
+     */
+    public function createApplication(): Application
+    {
+        $this->ensureEnvironmentFileExists();
+
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        $this->ensureSqliteDatabaseExists();
+
+        return $app;
+    }
+
+    private function ensureEnvironmentFileExists(): void
+    {
+        $basePath = dirname(__DIR__);
+        $environmentFile = $basePath.'/.env';
+
+        if (file_exists($environmentFile)) {
+            return;
+        }
+
+        $exampleFile = $basePath.'/.env.example';
+
+        if (file_exists($exampleFile)) {
+            copy($exampleFile, $environmentFile);
+        } else {
+            touch($environmentFile);
+        }
+    }
+
+    private function ensureSqliteDatabaseExists(): void
+    {
+        if (env('DB_CONNECTION') !== 'sqlite') {
+            return;
+        }
+
+        $databasePath = database_path('database.sqlite');
+
+        if (! file_exists($databasePath)) {
+            touch($databasePath);
+        }
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,5 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use CreatesApplication;
 }


### PR DESCRIPTION
## Summary
- ensure the test application boots with a copied environment file and sqlite database and configure PHPUnit to use it
- make migrations sqlite-friendly and adjust unique constraints to support multiple phones per person on an invoice
- skip Vite asset loading during tests to avoid missing manifest errors

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68de40bbc03c8331914098917df9f191