### PR TITLE
Enforce unique group values

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Group;
 use App\Models\Tariff;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class GroupController extends Controller
 {
@@ -23,16 +24,16 @@ class GroupController extends Controller
     }
     public function store(Request $request)
     {
-        $request->validate([
-            'name' => 'required',
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'value' => ['required', 'string', 'max:255', Rule::unique('groups', 'value')],
         ], [
             'name.required' => 'Název skupiny je povinný.',
+            'value.required' => 'Hodnota je povinná.',
+            'value.unique' => 'Tato hodnota je již použita jinou skupinou.',
         ]);
 
-        Group::create([
-            'name' => $request->input('name'),
-            'value' => $request->input('value'),
-        ]);
+        Group::create($validated);
 
         return redirect()->route('groups.index')->with('success', 'Skupina byla úspěšně vytvořena.');
     }
@@ -108,9 +109,17 @@ class GroupController extends Controller
 
         // Validace dat z požadavku
         $validated = $request->validate([
-            'name' => 'required|string|max:255',
+            'name' => ['required', 'string', 'max:255'],
+            'value' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('groups', 'value')->ignore($group->id),
+            ],
         ], [
             'name.required' => 'Název skupiny je povinný.',
+            'value.required' => 'Hodnota je povinná.',
+            'value.unique' => 'Tato hodnota je již použita jinou skupinou.',
         ]);
 
         // Aktualizace hodnoty skupiny

--- a/resources/js/Components/TariffGroupForm.vue
+++ b/resources/js/Components/TariffGroupForm.vue
@@ -65,7 +65,10 @@ const submit = () => {
             <input
                 v-model="localData.name"
                 type="text"
-                class="w-full rounded border px-3 py-2"
+                :class="[
+                    'w-full rounded border px-3 py-2',
+                    errors && errors.name ? 'border-red-500 focus:border-red-500 focus:ring-red-500' : 'border-gray-300 focus:border-blue-500 focus:ring-blue-500',
+                ]"
             />
             <div v-if="errors && errors.name" class="text-xs text-red-600">
                 {{ errors.name }}
@@ -78,7 +81,10 @@ const submit = () => {
             <input
                 v-model="localData.value"
                 type="text"
-                class="w-full rounded border px-3 py-2"
+                :class="[
+                    'w-full rounded border px-3 py-2',
+                    errors && errors.value ? 'border-red-500 focus:border-red-500 focus:ring-red-500' : 'border-gray-300 focus:border-blue-500 focus:ring-blue-500',
+                ]"
             />
             <div v-if="errors && errors.value" class="text-xs text-red-600">
                 {{ errors.value }}

--- a/tests/Feature/GroupControllerTest.php
+++ b/tests/Feature/GroupControllerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Models\Group;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\post;
+use function Pest\Laravel\put;
+
+it('requires a value when creating a group', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $response = post(route('groups.store'), [
+        'name' => 'Support Team',
+    ]);
+
+    $response->assertSessionHasErrors(['value']);
+
+    expect(Group::count())->toBe(0);
+});
+
+it('prevents updating a group with a duplicate value', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $existingGroup = Group::create([
+        'name' => 'Existing Group',
+        'value' => 'existing-value',
+    ]);
+
+    $group = Group::create([
+        'name' => 'Second Group',
+        'value' => 'second-value',
+    ]);
+
+    $response = put(route('groups.update', $group), [
+        'name' => 'Second Group Updated',
+        'value' => $existingGroup->value,
+    ]);
+
+    $response->assertSessionHasErrors(['value']);
+
+    $group->refresh();
+
+    expect($group->value)->toBe('second-value');
+});


### PR DESCRIPTION
## Summary
- add validation for the group value field to require uniqueness on create and update
- surface validation feedback in the tariff group form inputs
- cover missing or duplicate values with new feature tests

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68de50b3db3c83319e87512dcf2bb150