### PR TITLE
Move person limits to phone records

### DIFF
--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -20,11 +20,6 @@ class Person extends Model
     protected $fillable = [
         'name',
         'department',
-        'limit',
-    ];
-
-    protected $casts = [
-        'limit' => 'float',
     ];
 
     public function phones(): HasMany

--- a/app/Models/PersonPhone.php
+++ b/app/Models/PersonPhone.php
@@ -12,6 +12,11 @@ class PersonPhone extends Model
 
     protected $fillable = [
         'phone',
+        'limit',
+    ];
+
+    protected $casts = [
+        'limit' => 'float',
     ];
 
     public function person(): BelongsTo

--- a/app/Services/ImportService.php
+++ b/app/Services/ImportService.php
@@ -120,7 +120,7 @@ class ImportService
                 $vat = $entry['vat'];
                 $personData->name = $person->name;
                 $personData->phone = $phone;
-                $personData->limit = (float)$person->limit;
+                $personData->limit = (float) ($personPhone->limit ?? 0);
                 $personData->vat = $vat;
 
                 $platiSam = 0.0;

--- a/database/migrations/2025_10_05_120000_move_person_limit_to_person_phones.php
+++ b/database/migrations/2025_10_05_120000_move_person_limit_to_person_phones.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('person_phones')) {
+            return;
+        }
+
+        Schema::table('person_phones', function (Blueprint $table) {
+            if (! Schema::hasColumn('person_phones', 'limit')) {
+                $table->decimal('limit', 10, 2)->default(0);
+            }
+        });
+
+        $peopleLimits = Schema::hasTable('people')
+            ? DB::table('people')->pluck('limit', 'id')->all()
+            : [];
+
+        $phones = DB::table('person_phones')
+            ->select('id', 'person_id')
+            ->get();
+
+        foreach ($phones as $phone) {
+            $limit = $peopleLimits[$phone->person_id] ?? 0;
+
+            DB::table('person_phones')
+                ->where('id', $phone->id)
+                ->update(['limit' => $limit]);
+        }
+
+        if (Schema::hasTable('people') && Schema::hasColumn('people', 'limit')) {
+            Schema::table('people', function (Blueprint $table) {
+                $table->dropColumn('limit');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable('people') && ! Schema::hasColumn('people', 'limit')) {
+            Schema::table('people', function (Blueprint $table) {
+                $table->float('limit');
+            });
+        }
+
+        if (Schema::hasTable('person_phones') && Schema::hasColumn('person_phones', 'limit')) {
+            $limits = DB::table('person_phones')
+                ->select('person_id', 'limit')
+                ->get()
+                ->groupBy('person_id');
+
+            foreach ($limits as $personId => $entries) {
+                $limit = (float) ($entries->max('limit') ?? 0);
+
+                DB::table('people')
+                    ->where('id', $personId)
+                    ->update(['limit' => $limit]);
+            }
+
+            Schema::table('person_phones', function (Blueprint $table) {
+                $table->dropColumn('limit');
+            });
+        }
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,5 +19,9 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        $this->call([
+            PersonSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/PersonSeeder.php
+++ b/database/seeders/PersonSeeder.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Person;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\File;
+
+class PersonSeeder extends Seeder
+{
+    public function run(): void
+    {
+        foreach ($this->loadRows() as $row) {
+            $name = trim((string) Arr::get($row, 'name', ''));
+
+            if ($name === '') {
+                continue;
+            }
+
+            $person = Person::updateOrCreate(
+                ['name' => $name],
+                [
+                    'department' => trim((string) Arr::get($row, 'department', '')),
+                ]
+            );
+
+            foreach ($this->extractPhones($row) as $phone) {
+                $person->phones()->updateOrCreate(
+                    ['phone' => $phone['phone']],
+                    ['limit' => $phone['limit']]
+                );
+            }
+        }
+    }
+
+    private function loadRows(): array
+    {
+        $phpPath = database_path('seeders/data/persons.php');
+
+        if (File::exists($phpPath)) {
+            $data = require $phpPath;
+
+            if (is_array($data)) {
+                return $data;
+            }
+        }
+
+        $jsonPath = database_path('seeders/data/persons.json');
+
+        if (File::exists($jsonPath)) {
+            $data = json_decode(File::get($jsonPath), true);
+
+            if (is_array($data)) {
+                return $data;
+            }
+        }
+
+        return [];
+    }
+
+    private function extractPhones(array $row): array
+    {
+        $phones = [];
+        $entries = Arr::get($row, 'phones');
+
+        if (is_array($entries)) {
+            foreach ($entries as $entry) {
+                if (is_array($entry)) {
+                    $number = trim((string) Arr::get($entry, 'phone', ''));
+
+                    if ($number === '') {
+                        continue;
+                    }
+
+                    $phones[] = [
+                        'phone' => $number,
+                        'limit' => $this->castLimit(Arr::get($entry, 'limit', Arr::get($row, 'limit'))),
+                    ];
+
+                    continue;
+                }
+
+                if (is_string($entry)) {
+                    $number = trim($entry);
+
+                    if ($number === '') {
+                        continue;
+                    }
+
+                    $phones[] = [
+                        'phone' => $number,
+                        'limit' => $this->castLimit(Arr::get($row, 'limit')),
+                    ];
+                }
+            }
+
+            return $phones;
+        }
+
+        $singlePhone = Arr::get($row, 'phone');
+
+        if (is_string($singlePhone)) {
+            $number = trim($singlePhone);
+
+            if ($number !== '') {
+                $phones[] = [
+                    'phone' => $number,
+                    'limit' => $this->castLimit(Arr::get($row, 'limit')),
+                ];
+            }
+        }
+
+        return $phones;
+    }
+
+    private function castLimit(mixed $value): float
+    {
+        if ($value === null || $value === '') {
+            return 0.0;
+        }
+
+        if (is_string($value)) {
+            $normalized = str_replace(',', '.', $value);
+
+            if (is_numeric($normalized)) {
+                return round((float) $normalized, 2);
+            }
+
+            return 0.0;
+        }
+
+        if (is_numeric($value)) {
+            return round((float) $value, 2);
+        }
+
+        return 0.0;
+    }
+}

--- a/resources/js/Components/PersonForm.vue
+++ b/resources/js/Components/PersonForm.vue
@@ -3,9 +3,9 @@
         <form @submit.prevent="handleSubmit">
             <!-- Jméno -->
             <div class="mb-4">
-                <label for="name" class="mb-2 block font-semibold text-gray-700"
-                    >Jméno</label
-                >
+                <label for="name" class="mb-2 block font-semibold text-gray-700">
+                    Jméno
+                </label>
                 <input
                     id="name"
                     type="text"
@@ -23,26 +23,71 @@
                 <label class="mb-2 block font-semibold text-gray-700">
                     Telefonní čísla
                 </label>
+
                 <div
                     v-for="(phone, index) in formData.phones"
                     :key="`phone-${index}`"
-                    class="mb-2 flex items-start gap-2"
+                    class="mb-3 rounded-lg border border-gray-200 bg-white p-3"
                 >
-                    <input
-                        :id="`phone-${index}`"
-                        type="tel"
-                        v-model="formData.phones[index]"
-                        class="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-800 transition focus:border-blue-500 focus:ring focus:ring-blue-200"
-                        placeholder="Zadejte telefonní číslo"
-                    />
-                    <button
-                        type="button"
-                        class="rounded bg-red-500 px-3 py-2 text-sm font-semibold text-white transition hover:bg-red-600"
-                        @click="removePhone(index)"
-                    >
-                        Odebrat
-                    </button>
+                    <div class="grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,220px)_auto] sm:items-end">
+                        <div class="flex flex-col">
+                            <label
+                                :for="`phone-number-${index}`"
+                                class="mb-1 text-sm font-semibold text-gray-600"
+                            >
+                                Telefonní číslo
+                            </label>
+                            <input
+                                :id="`phone-number-${index}`"
+                                type="tel"
+                                v-model="formData.phones[index].phone"
+                                class="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-800 transition focus:border-blue-500 focus:ring focus:ring-blue-200"
+                                placeholder="Zadejte telefonní číslo"
+                            />
+                            <p
+                                v-if="phoneError(index, 'phone')"
+                                class="mt-1 text-sm text-red-500"
+                            >
+                                {{ phoneError(index, 'phone') }}
+                            </p>
+                        </div>
+
+                        <div class="flex flex-col">
+                            <label
+                                :for="`phone-limit-${index}`"
+                                class="mb-1 text-sm font-semibold text-gray-600"
+                            >
+                                Limit
+                            </label>
+                            <input
+                                :id="`phone-limit-${index}`"
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                v-model="formData.phones[index].limit"
+                                class="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-800 transition focus:border-blue-500 focus:ring focus:ring-blue-200"
+                                placeholder="Zadejte limit"
+                            />
+                            <p
+                                v-if="phoneError(index, 'limit')"
+                                class="mt-1 text-sm text-red-500"
+                            >
+                                {{ phoneError(index, 'limit') }}
+                            </p>
+                        </div>
+
+                        <div class="flex justify-end">
+                            <button
+                                type="button"
+                                class="rounded bg-red-500 px-3 py-2 text-sm font-semibold text-white transition hover:bg-red-600"
+                                @click="removePhone(index)"
+                            >
+                                Odebrat
+                            </button>
+                        </div>
+                    </div>
                 </div>
+
                 <button
                     type="button"
                     class="rounded bg-green-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-green-600"
@@ -53,14 +98,6 @@
                 <p v-if="errors.phones" class="mt-2 text-sm text-red-500">
                     {{ errors.phones }}
                 </p>
-                <template v-for="(phone, index) in formData.phones" :key="`error-${index}`">
-                    <p
-                        v-if="errors[`phones.${index}`]"
-                        class="mt-1 text-sm text-red-500"
-                    >
-                        {{ errors[`phones.${index}`] }}
-                    </p>
-                </template>
             </div>
 
             <!-- Pracovní útvar -->
@@ -68,8 +105,9 @@
                 <label
                     for="department"
                     class="mb-2 block font-semibold text-gray-700"
-                    >Pracovní útvar</label
                 >
+                    Pracovní útvar
+                </label>
                 <input
                     id="department"
                     type="text"
@@ -79,26 +117,6 @@
                 />
                 <p v-if="errors.department" class="mt-1 text-sm text-red-500">
                     {{ errors.department }}
-                </p>
-            </div>
-
-            <!-- Limit -->
-            <div class="mb-4">
-                <label
-                    for="limit"
-                    class="mb-2 block font-semibold text-gray-700"
-                    >Limit</label
-                >
-                <input
-                    id="limit"
-                    type="number"
-                    step="0.1"
-                    v-model="formData.limit"
-                    class="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-800 transition focus:border-blue-500 focus:ring focus:ring-blue-200"
-                    placeholder="Zadejte limit"
-                />
-                <p v-if="errors.limit" class="mt-1 text-sm text-red-500">
-                    {{ errors.limit }}
                 </p>
             </div>
 
@@ -116,16 +134,22 @@
 </template>
 
 <script setup>
-import { reactive, watch } from 'vue';
+import { reactive, watch, computed } from 'vue';
+
+const DEFAULT_PHONE_LIMIT = '450';
 
 const props = defineProps({
     initialData: {
         type: Object,
         default: () => ({
             name: '',
-            phones: [''],
+            phones: [
+                {
+                    phone: '',
+                    limit: DEFAULT_PHONE_LIMIT,
+                },
+            ],
             department: '',
-            limit: 450,
         }),
     },
     errors: {
@@ -138,45 +162,70 @@ const props = defineProps({
     },
 });
 
+const errors = computed(() => props.errors ?? {});
+
 const emit = defineEmits(['submit']);
 
 const formData = reactive({
     id: null,
     name: '',
-    phones: [''],
+    phones: [createPhoneEntry('', DEFAULT_PHONE_LIMIT, DEFAULT_PHONE_LIMIT)],
     department: '',
-    limit: 450,
+});
+
+const formatLimit = (value, fallback = '') => {
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? String(value) : fallback;
+    }
+
+    if (typeof value === 'string') {
+        const normalized = value.replace(',', '.');
+        return Number.isFinite(Number(normalized)) ? normalized : fallback;
+    }
+
+    return fallback;
+};
+
+const createPhoneEntry = (phone = '', limit = '', fallback = '') => ({
+    phone: typeof phone === 'string' ? phone : '',
+    limit: formatLimit(limit, fallback),
 });
 
 const normalizePhones = (phones) => {
     if (!Array.isArray(phones) || phones.length === 0) {
-        return [''];
+        return [createPhoneEntry('', DEFAULT_PHONE_LIMIT, DEFAULT_PHONE_LIMIT)];
     }
 
-    const values = phones.map((entry) => {
-        if (typeof entry === 'object' && entry !== null) {
-            return entry.phone ?? '';
-        }
+    const normalized = phones
+        .map((entry) => {
+            if (entry && typeof entry === 'object') {
+                return createPhoneEntry(entry.phone ?? '', entry.limit ?? '', '');
+            }
 
-        return typeof entry === 'string' ? entry : '';
-    });
+            if (typeof entry === 'string') {
+                return createPhoneEntry(entry, '', '');
+            }
 
-    return values.length ? values : [''];
+            return createPhoneEntry('', '', '');
+        })
+        .filter((entry) => entry.phone !== '');
+
+    return normalized.length
+        ? normalized
+        : [createPhoneEntry('', DEFAULT_PHONE_LIMIT, DEFAULT_PHONE_LIMIT)];
 };
 
 const setFormData = (data) => {
     formData.id = data?.id ?? null;
     formData.name = data?.name ?? '';
     formData.department = data?.department ?? '';
-    formData.limit = data?.limit ?? 450;
 
-    const phones = normalizePhones(data?.phones ?? ['']);
-
+    const phones = normalizePhones(data?.phones ?? []);
     formData.phones.splice(0, formData.phones.length, ...phones);
-
-    if (formData.phones.length === 0) {
-        formData.phones.push('');
-    }
 };
 
 setFormData(props.initialData);
@@ -190,16 +239,46 @@ watch(
 );
 
 const addPhone = () => {
-    formData.phones.push('');
+    formData.phones.push(createPhoneEntry('', DEFAULT_PHONE_LIMIT, DEFAULT_PHONE_LIMIT));
 };
 
 const removePhone = (index) => {
     if (formData.phones.length === 1) {
-        formData.phones.splice(0, 1, '');
+        formData.phones.splice(
+            0,
+            1,
+            createPhoneEntry('', DEFAULT_PHONE_LIMIT, DEFAULT_PHONE_LIMIT),
+        );
         return;
     }
 
     formData.phones.splice(index, 1);
+};
+
+const parseLimit = (value) => {
+    if (value === null || value === undefined || value === '') {
+        return null;
+    }
+
+    const normalized = typeof value === 'string' ? value.replace(',', '.') : value;
+    const number = Number(normalized);
+
+    if (!Number.isFinite(number)) {
+        return null;
+    }
+
+    return Math.round(number * 100) / 100;
+};
+
+const phoneError = (index, field) => {
+    const currentErrors = errors.value;
+    const baseKey = `phones.${index}`;
+
+    return (
+        currentErrors[`${baseKey}.${field}`] ??
+        currentErrors[baseKey] ??
+        null
+    );
 };
 
 const handleSubmit = () => {
@@ -207,10 +286,12 @@ const handleSubmit = () => {
         id: formData.id,
         name: formData.name,
         department: formData.department,
-        limit: formData.limit,
         phones: formData.phones
-            .map((phone) => (typeof phone === 'string' ? phone.trim() : ''))
-            .filter((phone) => phone !== ''),
+            .map((entry) => ({
+                phone: typeof entry.phone === 'string' ? entry.phone.trim() : '',
+                limit: parseLimit(entry.limit),
+            }))
+            .filter((entry) => entry.phone !== ''),
     };
 
     emit('submit', payload);

--- a/resources/js/Pages/Osoby.vue
+++ b/resources/js/Pages/Osoby.vue
@@ -8,12 +8,17 @@ import PersonTable from '../Components/PersonTable.vue';
 const personFormRef = ref(null);
 const showForm = ref(false);
 const isEditing = ref(false);
+const DEFAULT_PHONE_LIMIT = 450;
 const formData = reactive({
     id: null,
     name: '',
-    phones: [''],
+    phones: [
+        {
+            phone: '',
+            limit: DEFAULT_PHONE_LIMIT,
+        },
+    ],
     department: '',
-    limit: 450,
 });
 
 // Pro přiřazování skupin
@@ -55,9 +60,13 @@ const toggleForm = () => {
 const resetForm = () => {
     formData.id = null;
     formData.name = '';
-    formData.phones = [''];
+    formData.phones = [
+        {
+            phone: '',
+            limit: DEFAULT_PHONE_LIMIT,
+        },
+    ];
     formData.department = '';
-    formData.limit = 450;
     isEditing.value = false;
     showForm.value = false;
 };
@@ -114,9 +123,31 @@ const editPerson = (person) => {
     formData.id = person.id;
     formData.name = person.name;
     formData.department = person.department;
-    formData.limit = person.limit;
-    const phones = extractPhones(person);
-    formData.phones = phones.length ? phones : [''];
+    const phones = Array.isArray(person.phones)
+        ? person.phones
+              .map((entry) => ({
+                  phone:
+                      entry && typeof entry === 'object'
+                          ? entry.phone ?? ''
+                          : typeof entry === 'string'
+                            ? entry
+                            : '',
+                  limit:
+                      entry && typeof entry === 'object'
+                          ? entry.limit ?? DEFAULT_PHONE_LIMIT
+                          : DEFAULT_PHONE_LIMIT,
+              }))
+              .filter((entry) => entry.phone !== '')
+        : [];
+
+    formData.phones = phones.length
+        ? phones
+        : [
+              {
+                  phone: '',
+                  limit: DEFAULT_PHONE_LIMIT,
+              },
+          ];
     isEditing.value = true;
     showForm.value = true;
     setTimeout(() => {


### PR DESCRIPTION
## Summary
- add a migration that moves the limit column from people to person_phones and updates the seeder/model setup
- update controllers and services to validate, persist, and expose per-phone limits instead of person-level limits
- refresh the Vue form/table to capture phone limits and send `{ phone, limit }` payloads

## Testing
- php artisan migrate
- php artisan db:seed

------
https://chatgpt.com/codex/tasks/task_e_68de61c81cf08331a314bfe0ca274b61