### PR TITLE
Fix invoice person assignment in ImportService

### DIFF
--- a/app/Services/ImportService.php
+++ b/app/Services/ImportService.php
@@ -226,7 +226,7 @@ class ImportService
                 'applied_rules' => $personData->aplikovanaPravidla ?: null,
             ]);
 
-            $personData->invoice_person_id = $invoicePerson->id;
+            $personData->invoicePersonId = $invoicePerson->id;
 
             foreach ($personData->sluzby as $service) {
                 $invoicePerson->lines()->create([

--- a/tests/Feature/PersonPhoneTest.php
+++ b/tests/Feature/PersonPhoneTest.php
@@ -132,4 +132,13 @@ it('imports invoice rows for every matching phone number', function () {
         ->and($invoice->people)->toHaveCount(2)
         ->and($invoice->people->pluck('phone')->all())
         ->toEqualCanonicalizing($phones);
+
+    $responseData = $result['data'][$person->name] ?? [];
+
+    expect($responseData)->not->toBeEmpty();
+
+    foreach ($phones as $phone) {
+        expect($responseData[$phone]['invoice_person_id'] ?? null)
+            ->not->toBeNull();
+    }
 });


### PR DESCRIPTION
## Summary
- ensure ImportService assigns the invoice person id to the DTO's camelCase property
- extend the import feature test to assert invoice_person_id values are returned in the response

## Testing
- php artisan test --testsuite=Feature --filter=imports

------
https://chatgpt.com/codex/tasks/task_e_68de6b7a01108331aca5cea5139fb628